### PR TITLE
Support new uuid module vs old deprecated one

### DIFF
--- a/src/systemJSConfig.js
+++ b/src/systemJSConfig.js
@@ -12,5 +12,8 @@ SystemJS.config({
   packageConfigPaths: ['/node_modules/*/package.json'],
   packages: {
     "/build": {defaultExtension: "js"},
+    "uuid": {
+      map: {"./lib/rng": "./lib/rng-browser"}
+    }
   },
 });


### PR DESCRIPTION
Must be released in conjunction with: https://github.com/witheve/Eve/pull/827 being published as part of `0.3.0-preview3`.

SystemJS doesn't utilize the `browser` remapping that the new uuid module uses, so we need to manually remap `rng.js` to `rng-browser.js`.