### PR TITLE
Add default styling for buttons

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -20,19 +20,20 @@ text { display: inline-block; white-space: pre-wrap; }
 
 .button:not(:empty):before { margin-right: 10px; }
 
-.button.inset { border-radius: 4px; background: #EEE; border: 1px solid rgba(0, 0, 0, 0.1); }
-.button.inset:not(.disabled):hover { box-shadow: inset 0 0 1000px rgba(0, 0, 0, 0.05), inset 0 1px 1px rgba(0, 0, 0, 0.25); border-top-color: rgba(0, 0, 0, 0.2); }
-.button.inset:not(.disabled):active { box-shadow: inset 0 0 1000px rgba(0, 0, 0, 0.1), inset 0 2px 1px rgba(0, 0, 0, 0.25); border-top-color: rgba(0, 0, 0, 0.3); }
+.button { background: #f0f0f0; border-radius: 4px; border: 1px solid #e5e5e5; }
+.button:hover { background: #e9e9e9; }
+.button:active { background: #e0e0e0; }
 
+.button.inset { border-radius: 4px; background: #EEE; border: 1px solid rgba(0, 0, 0, 0.1); }
+.button.inset:not(.disabled):hover { background: #EEE; box-shadow: inset 0 0 1000px rgba(0, 0, 0, 0.05), inset 0 1px 1px rgba(0, 0, 0, 0.25); border-top-color: rgba(0, 0, 0, 0.2); }
+.button.inset:not(.disabled):active { background: #EEE; box-shadow: inset 0 0 1000px rgba(0, 0, 0, 0.1), inset 0 2px 1px rgba(0, 0, 0, 0.25); border-top-color: rgba(0, 0, 0, 0.3); }
+
+.button.flat { background: transparent; border: none; border-radius: 0; }
 .button.flat:not(.disabled):hover { background: rgba(0, 0, 0, 0.05); }
 .button.flat:not(.disabled):active { background: rgba(0, 0, 0, 0.1); }
 
 .dark .button.flat:not(.disabled):hover { background: rgba(255, 255, 255, 0.1); }
 .dark .button.flat:not(.disabled):active { background: rgba(255, 255, 255, 0.2); }
-
-.button:not(.flat):not(.inset) { background: #f0f0f0; border-radius: 4px; border: 1px solid #e5e5e5; }
-.button:not(.flat):not(.inset):hover { background: #e9e9e9; }
-.button:not(.flat):not(.inset):active { background: #e0e0e0; }
 
 .ui-field-table {border-collapse: collapse;}
 .ui-field-table td {padding: 0;margin: 0;vertical-align: top; border: 1px solid #ccc;}

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -18,7 +18,7 @@ text { display: inline-block; white-space: pre-wrap; }
 
 .button:before { align-self: center; }
 
-.button:not(:empty):before { margin-right: 10; }
+.button:not(:empty):before { margin-right: 10px; }
 
 .button.inset { border-radius: 4px; background: #EEE; border: 1px solid rgba(0, 0, 0, 0.1); }
 .button.inset:not(.disabled):hover { box-shadow: inset 0 0 1000px rgba(0, 0, 0, 0.05), inset 0 1px 1px rgba(0, 0, 0, 0.25); border-top-color: rgba(0, 0, 0, 0.2); }
@@ -29,6 +29,10 @@ text { display: inline-block; white-space: pre-wrap; }
 
 .dark .button.flat:not(.disabled):hover { background: rgba(255, 255, 255, 0.1); }
 .dark .button.flat:not(.disabled):active { background: rgba(255, 255, 255, 0.2); }
+
+.button:not(.flat):not(.inset) { background: #f0f0f0; border-radius: 4px; border: 1px solid #e5e5e5; }
+.button:not(.flat):not(.inset):hover { background: #e9e9e9; }
+.button:not(.flat):not(.inset):active { background: #e0e0e0; }
 
 .ui-field-table {border-collapse: collapse;}
 .ui-field-table td {padding: 0;margin: 0;vertical-align: top; border: 1px solid #ccc;}
@@ -41,7 +45,7 @@ text { display: inline-block; white-space: pre-wrap; }
 .ui-field-table input::-webkit-input-placeholder { font-weight: 300; }
 .ui-field-table input.ui-field-table-attribute {padding-right: 0;}
 
-.ui-autocomplete { position: relative; flex: 0 0 auto; width: 200px;}
+.ui-autocomplete { position: relative; flex: 0 0 auto; width: 200px; }
 .ui-autocomplete-matches { position: absolute; top: 100%; width: 100%; flex: 0 0 auto; z-index: 5; background: white; border-top: 0px solid #f0f0f0; border-radius: 4px; box-shadow: 0 2px 3px rgba(0, 0, 0, 0.2); }
 .ui-autocomplete[open="true"] .ui-autocomplete-matches { border-top-width: 1px; }
 

--- a/programs/program-switcher.ts
+++ b/programs/program-switcher.ts
@@ -77,7 +77,7 @@ prog
     return [
       container.add("children", [
         record("ui/text", {sort: 0, class: "header", text: "Select a program"}),
-        record("program-button", "ui/button", {sort: program.url, program, text: program.url})
+        record("program-button", "ui/a", {sort: program.url, program, text: program.url})
       ])
     ];
   })

--- a/programs/ui-demo.ts
+++ b/programs/ui-demo.ts
@@ -47,11 +47,15 @@ prog.bind("Demo button.", ({record}) => {
   return [
     record("container", {sort: 3, example}).add("children", [
       record("ui/column", {sort: 2, example, style: record({flex: 1, "justify-content": "space-around"})}).add("children", [
+        record("ui/row", {sort: 1, example, kind: "default"}).add("children", [
+          record("ui/button", {sort: 1, text: "default", style: record({flex: 1})}),
+          record("ui/button", {sort: 2, icon: "alert-circled"}),
+        ]),
+
         record("ui/row", {sort: 1, example, kind: "inset"}).add("children", [
           record("ui/button", {sort: 1, class: "inset", text: "inset", style: record({flex: 1})}),
           record("ui/button", {sort: 2, class: "inset", icon: "alert-circled"}),
         ]),
-        record("ui/button", {sort: 2, class: "inset", text: "inset", icon: "alert-circled"}),
 
         record("ui/row", {sort: 3, example, kind: "flat"}).add("children", [
           record("ui/button", {sort: 1, class: "flat", text: "flat", style: record({flex: 1})}),


### PR DESCRIPTION
When Robert demo'd the new quickstart, he was surprised that the button looked like plain text. We could require the user to add a class to style the button, but we could also just style buttons by default. This is a little annoying in the case that you have your own styles you want to apply, but there are other solutions around that which we've discussed adding in the near future (like dynamic class-generating styles).