### PR TITLE
Revert incorrect attempt to simplify scoring block

### DIFF
--- a/programs/tic-tac-toe.eve
+++ b/programs/tic-tac-toe.eve
@@ -71,8 +71,8 @@ search
   else if cell = [#cell column player] N = gather/count[for: cell per: (column, player)] then (player, cell)
   else if cell = [#diagonal player] N = gather/count[for: cell per: player] then (player, cell)
   else if cell = [#anti-diagonal player] N = gather/count[for: cell per: player] then (player, cell)
-  //else if N * N = gather/count[for: [#cell player]] then ("nobody", "nothing") // Cat's game!
-  else if not([#cell not(player)]) then ("nobody", "nothing")
+  //else if N * N = gather/count[for: [#cell player]] then ("Nobody", "nothing") // Cat's game!
+  else if not([#cell not(player)]) then ("Nobody", "nothing")
 
 commit
   board.winner := winner
@@ -153,8 +153,8 @@ search
              else ""
 
 bind
-    [#ui/div board #container | style: [font-family: "sans-serif"] children:
-        [#ui/div #status board class: "status" | style: [text-align: "center" width: "150px" height: "50px" padding-bottom: "10px"]]
+    [#ui/div board #container | style: [font-family: "sans-serif" padding: "10px"] children:
+        [#ui/div #status board class: "status" | style: [text-align: "center" width: "150px" height: "50px"]]
         [#ui/div board class: "board" | style: [color: "black"] children:
             [#ui/div board class: "row" sort: row, | children:
                 [#ui/div #cell-div cell class: "cell" sort: column text: contents |

--- a/programs/tic-tac-toe.eve
+++ b/programs/tic-tac-toe.eve
@@ -71,7 +71,8 @@ search
   else if cell = [#cell column player] N = gather/count[for: cell per: (column, player)] then (player, cell)
   else if cell = [#diagonal player] N = gather/count[for: cell per: player] then (player, cell)
   else if cell = [#anti-diagonal player] N = gather/count[for: cell per: player] then (player, cell)
-  else if N * N = gather/count[for: [#cell]] then ("nobody", "nothing") // Cat's game!
+  //else if N * N = gather/count[for: [#cell player]] then ("nobody", "nothing") // Cat's game!
+  else if not([#cell not(player)]) then ("nobody", "nothing")
 
 commit
   board.winner := winner

--- a/programs/tic-tac-toe.eve
+++ b/programs/tic-tac-toe.eve
@@ -63,21 +63,15 @@ where `N` is the size of the board.
 A game is won when a player marks N cells in a row, column, or diagonal.
 The game can end in a tie, where no player has N in a row.
 
-@FIXME: This is broken currently, apparently due to the win condition checking happening within a choose.
-
 ~~~
 search
   board = [#board size: N, not(winner)]
-  cell = [#cell row column player]
-
   (winner, winning-cell) =
-    if N = gather/count[for: cell per: (row, player)] then (player, cell)
-    else if N = gather/count[for: cell per: (column, player)] then (player, cell)
-    else if cell = [#diagonal row column player]
-            N = gather/count[for: cell per: player] then (player, cell)
-    else if cell = [#anti-diagonal row column player]
-            N = gather/count[for: cell per: player] then (player, cell)
-    else if N * N = gather/count[for: cell] then ("nobody", "nothing") // Cat's game!
+  if cell = [#cell row player] N = gather/count[for: cell per: (row, player)] then (player, cell)
+  else if cell = [#cell column player] N = gather/count[for: cell per: (column, player)] then (player, cell)
+  else if cell = [#diagonal player] N = gather/count[for: cell per: player] then (player, cell)
+  else if cell = [#anti-diagonal player] N = gather/count[for: cell per: player] then (player, cell)
+  else if N * N = gather/count[for: [#cell]] then ("nobody", "nothing") // Cat's game!
 
 commit
   board.winner := winner


### PR DESCRIPTION
Fix #18.

See https://github.com/witheve/eve-starter/issues/18 for explanation.