### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install
 
 ## Using the Starter
 
-If you want to explore the bundled examples you can start the program switcher, which allows you to explore them from your browser. Any `*.eve` files places into the `eve-starter/programs` directory will be shown here.
+If you want to explore the bundled examples you can start the program switcher, which allows you to explore them from your browser. Any `*.eve` files placed into the `eve-starter/programs` directory will be shown here.
 
 ```sh
 npm start

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "setimmediate": "^1.0.5",
     "typescript": "~2.2.1",
     "uuid": "^3.0.1",
-    "witheve": "git://github.com/witheve/eve.git#master",
+    "witheve": "preview",
     "ws": "^1.1.1"
   }
 }


### PR DESCRIPTION
just taking a look at Eve and noticed a typo in the README
places => placed